### PR TITLE
Unify attribute names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Release 0.3.0
 
+### Breaking Changes
+- `with_notion` now needs to be wrapped inside `bounce`.
+
 ### Other Changes
 
 - Added Artifact API

--- a/book-src/core-api.md
+++ b/book-src/core-api.md
@@ -206,7 +206,7 @@ An action that can be applied to multiple states.
 When a notion is applied, it will be broadcasted to all states that
 listen to this notion.
 
-To listen to a notion, apply `#[with_notion(NotionType)]` tag to your
+To listen to a notion, apply `#[bounce(with_notion(NotionType))]` tag to your
 slice or atom and define how it can be applied with the
 `WithNotion<NotionType>` trait.
 
@@ -221,7 +221,7 @@ pub enum CounterAction {
 }
 
 #[derive(Slice, PartialEq, Default)]
-#[with_notion(Reset)] // The slice that listens to a notion of type T needs to be denoted with `#[with_notion(T)]`.
+#[bounce(with_notion(Reset))] // The slice that listens to a notion of type T needs to be denoted with `#[bounce(with_notion(T))]`.
 pub struct Counter {
     inner: u32
 }
@@ -241,7 +241,7 @@ impl Reducible for Counter {
     }
 }
 
-// A WithNotion<T> is required for each notion denoted in the #[with_notion] attribute.
+// A WithNotion<T> is required for each notion denoted in the #[bounce(with_notion(T))] attribute.
 impl WithNotion<Reset> for Counter {
     fn apply(self: Rc<Self>, _notion: Rc<Reset>) -> Rc<Self> {
         Self::default().into()
@@ -286,7 +286,7 @@ the Deferred notion.
 
 ```rust
 #[derive(PartialEq, Default, Atom)]
-#[with_notion(Deferred<FetchUser>)]  // A future notion with type `T` will be applied as `Deferred<T>`.
+#[bounce(with_notion(Deferred<FetchUser>))]  // A future notion with type `T` will be applied as `Deferred<T>`.
 struct UserState {
     inner: Option<Rc<User>>,
 }

--- a/crates/bounce-macros/src/atom.rs
+++ b/crates/bounce-macros/src/atom.rs
@@ -18,7 +18,7 @@ pub(crate) fn macro_fn(input: DeriveInput) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    let impl_observed = bounce_attrs.observed.then(|| {
+    let impl_observed = bounce_attrs.observed.is_some().then(|| {
         quote! {
             fn changed(self: ::std::rc::Rc<Self>) {
                 ::bounce::Observed::changed(self);

--- a/crates/bounce-macros/src/atom.rs
+++ b/crates/bounce-macros/src/atom.rs
@@ -2,27 +2,23 @@ use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{DeriveInput, Ident};
 
-use super::slice::{create_notion_apply_impls, parse_find_observed, parse_with_notion_attrs};
+use super::slice::BounceAttrs;
 
 pub(crate) fn macro_fn(input: DeriveInput) -> TokenStream {
-    let notion_idents = match parse_with_notion_attrs(input.clone()) {
-        Ok(m) => m,
-        Err(e) => return e.into_compile_error(),
-    };
-
-    let observed = match parse_find_observed(input.clone()) {
+    let bounce_attrs = match BounceAttrs::parse(&input.attrs) {
         Ok(m) => m,
         Err(e) => return e.into_compile_error(),
     };
 
     let notion_ident = Ident::new("notion", Span::mixed_site());
-    let notion_apply_impls = create_notion_apply_impls(&notion_ident, &notion_idents);
+    let notion_apply_impls = bounce_attrs.create_notion_apply_impls(&notion_ident);
+    let notion_ids_impls = bounce_attrs.create_notion_id_impls();
 
     let ident = input.ident;
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    let impl_observed = observed.then(|| {
+    let impl_observed = bounce_attrs.observed.then(|| {
         quote! {
             fn changed(self: ::std::rc::Rc<Self>) {
                 ::bounce::Observed::changed(self);
@@ -40,7 +36,7 @@ pub(crate) fn macro_fn(input: DeriveInput) -> TokenStream {
             }
 
             fn notion_ids(&self) -> ::std::vec::Vec<::std::any::TypeId> {
-                ::std::vec![#(::std::any::TypeId::of::<#notion_idents>(),)*]
+                ::std::vec![#(#notion_ids_impls,)*]
             }
 
             #impl_observed

--- a/crates/bounce-macros/src/lib.rs
+++ b/crates/bounce-macros/src/lib.rs
@@ -6,14 +6,14 @@ mod atom;
 mod future_notion;
 mod slice;
 
-#[proc_macro_derive(Atom, attributes(with_notion, observed))]
+#[proc_macro_derive(Atom, attributes(bounce))]
 #[proc_macro_error]
 pub fn atom(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     atom::macro_fn(input).into()
 }
 
-#[proc_macro_derive(Slice, attributes(with_notion, observed))]
+#[proc_macro_derive(Slice, attributes(bounce))]
 #[proc_macro_error]
 pub fn slice(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/crates/bounce-macros/src/slice.rs
+++ b/crates/bounce-macros/src/slice.rs
@@ -4,7 +4,7 @@ use syn::parse::discouraged::Speculative;
 use syn::parse::{Parse, ParseBuffer, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
-use syn::{parenthesized, Attribute, DeriveInput, Ident, Meta, Type};
+use syn::{parenthesized, Attribute, DeriveInput, Ident, Type};
 
 pub(crate) struct WithNotionAttr {
     notion_idents: Vec<Type>,

--- a/crates/bounce/src/query/mutation.rs
+++ b/crates/bounce/src/query/mutation.rs
@@ -122,7 +122,7 @@ enum MutationStateAction {
 }
 
 #[derive(Slice, Debug)]
-#[with_notion(Deferred<RunMutation<T>>)]
+#[bounce(with_notion(Deferred<RunMutation<T>>))]
 struct MutationState<T>
 where
     T: Mutation + 'static,

--- a/crates/bounce/src/query/query_.rs
+++ b/crates/bounce/src/query/query_.rs
@@ -218,7 +218,7 @@ where
 }
 
 #[derive(Slice)]
-#[with_notion(Deferred<RunQuery<T>>)]
+#[bounce(with_notion(Deferred<RunQuery<T>>))]
 struct QueryState<T>
 where
     T: Query + 'static,

--- a/crates/bounce/src/states/future_notion.rs
+++ b/crates/bounce/src/states/future_notion.rs
@@ -170,7 +170,7 @@ where
 /// }
 ///
 /// #[derive(PartialEq, Default, Atom)]
-/// #[with_notion(Deferred<FetchUser>)]  // A future notion with type `T` will be applied as `Deferred<T>`.
+/// #[bounce(with_notion(Deferred<FetchUser>))]  // A future notion with type `T` will be applied as `Deferred<T>`.
 /// struct UserState {
 ///     inner: Option<Rc<User>>,
 /// }

--- a/crates/bounce/src/states/notion.rs
+++ b/crates/bounce/src/states/notion.rs
@@ -39,12 +39,12 @@ pub trait WithNotion<T: 'static> {
 /// pub struct Reset;
 ///
 /// #[derive(PartialEq, Atom)]
-/// #[with_notion(Reset)] // A #[with_notion(Notion)] needs to be denoted for the notion.
+/// #[bounce(with_notion(Reset))] // A #[bounce(with_notion(Notion))] needs to be denoted for the notion.
 /// struct Username {
 ///     inner: String,
 /// }
 ///
-/// // A WithNotion<T> is required for each notion denoted in the #[with_notion] attribute.
+/// // A WithNotion<T> is required for each notion denoted in the #[bounce(with_notion)] attribute.
 /// impl WithNotion<Reset> for Username {
 ///     fn apply(self: Rc<Self>, _notion: Rc<Reset>) -> Rc<Self> {
 ///         Self::default().into()
@@ -53,7 +53,7 @@ pub trait WithNotion<T: 'static> {
 ///
 /// // second state
 /// #[derive(PartialEq, Atom, Default)]
-/// #[with_notion(Reset)]
+/// #[bounce(with_notion(Reset))]
 /// struct Session {
 ///     token: Option<String>,
 /// }

--- a/crates/bounce/src/states/observer.rs
+++ b/crates/bounce/src/states/observer.rs
@@ -12,7 +12,7 @@ use std::rc::Rc;
 /// use std::rc::Rc;
 ///
 /// #[derive(Atom, PartialEq, Default)]
-/// #[observed] // observed states need to be denoted with the observed attribute.
+/// #[bounce(observed)] // observed states need to be denoted with the observed attribute.
 /// struct State {
 ///     value: usize,
 /// }

--- a/crates/bounce/tests/notion.rs
+++ b/crates/bounce/tests/notion.rs
@@ -25,7 +25,7 @@ async fn get_text_content<S: AsRef<str>>(selector: S) -> String {
 #[test]
 async fn test_notion_generic() {
     #[derive(Atom, PartialEq, Default)]
-    #[with_notion(State<T>)]
+    #[bounce(with_notion(State<T>))]
     struct State<T>
     where
         T: PartialEq + Default + 'static,

--- a/examples/notion/src/main.rs
+++ b/examples/notion/src/main.rs
@@ -15,8 +15,8 @@ pub enum SliceAction {
 }
 
 #[derive(Default, PartialEq, Slice)]
-#[with_notion(SliceAction)]
-#[with_notion(Reset)]
+#[bounce(with_notion(SliceAction))]
+#[bounce(with_notion(Reset))]
 pub struct SliceA(i64);
 
 impl Reducible for SliceA {
@@ -44,8 +44,8 @@ impl WithNotion<Reset> for SliceA {
 }
 
 #[derive(Default, PartialEq, Slice)]
-#[with_notion(SliceAction)]
-#[with_notion(Reset)]
+#[bounce(with_notion(SliceAction))]
+#[bounce(with_notion(Reset))]
 pub struct SliceB(i64);
 
 impl Reducible for SliceB {
@@ -73,8 +73,8 @@ impl WithNotion<Reset> for SliceB {
 }
 
 #[derive(Default, PartialEq, Slice)]
-#[with_notion(SliceAction)]
-#[with_notion(Reset)]
+#[bounce(with_notion(SliceAction))]
+#[bounce(with_notion(Reset))]
 pub struct SliceC(i64);
 
 impl Reducible for SliceC {

--- a/examples/persist/src/main.rs
+++ b/examples/persist/src/main.rs
@@ -9,7 +9,7 @@ use yew::prelude::*;
 use yew::InputEvent;
 
 #[derive(PartialEq, Atom)]
-#[observed]
+#[bounce(observed)]
 struct Username {
     inner: String,
 }

--- a/examples/random-uuid/src/main.rs
+++ b/examples/random-uuid/src/main.rs
@@ -25,7 +25,7 @@ async fn fetch_uuid(_input: &()) -> String {
 }
 
 #[derive(PartialEq, Atom)]
-#[with_notion(Deferred<FetchUuid>)]
+#[bounce(with_notion(Deferred<FetchUuid>))]
 enum UuidState {
     NotStarted,
     Pending,


### PR DESCRIPTION
### Description

<!--Fix #0000-->

This pull request consists of the following changes:

<!--please provide a list of changes included in this pull request.-->

- Make all attributes of derive macros to be declared under`#[bounce(...)]`

### Checklist

- [x] I have self-reviewed and tested this pull request to my best ability.
- [x] I have added tests for my changes.
- [x] I have updated docs to reflect any new features / changes in this pull request.
- [x] I have added my changes to `CHANGELOG.md`.
