### PR TITLE
Invalidate Query when the states it has queried has become outdated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added Helmet API
 - Added Observer API
 - Notion is now registered and does not iterate over all states.
+- Fixed a bug where the query will not requery itself if any state it
+  selected has updated.
 
 ## Release 0.2.0
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -41,12 +41,26 @@ workspace = true
 command = "wasm-pack"
 args = ["test", "--headless", "--firefox"]
 
+# wasm-pack test --headless --firefox --all-features
+[tasks.wasm-test-all-features]
+private = true
+workspace = true
+command = "wasm-pack"
+args = ["test", "--headless", "--firefox", "--all-features"]
+
 # cargo test
 [tasks.native-test]
 private = true
 workspace = true
 command = "cargo"
 args = ["test"]
+
+# cargo test --all-features
+[tasks.native-test-all-features]
+private = true
+workspace = true
+command = "cargo"
+args = ["test", "--all-features"]
 
 # cargo test --doc --all-features
 [tasks.doc-test]
@@ -61,5 +75,5 @@ args = ["test", "--doc", "--all-features", "--workspace"]
 workspace = false
 
 [tasks.tests.run_task]
-name = ["wasm-test", "native-test", "doc-test"]
+name = ["wasm-test", "wasm-test-all-features", "native-test", "native-test-all-features", "doc-test"]
 fork = true

--- a/crates/bounce-macros/Cargo.toml
+++ b/crates/bounce-macros/Cargo.toml
@@ -18,6 +18,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro-error = "1.0.4"
-proc-macro2 = "1.0.36"
-quote = "1.0.14"
-syn = { version = "1.0.84", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0.37"
+quote = "1.0.18"
+syn = { version = "1.0.92", features = ["full", "extra-traits"] }

--- a/crates/bounce/Cargo.toml
+++ b/crates/bounce/Cargo.toml
@@ -15,17 +15,17 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anymap2 = "0.13.0"
-once_cell = "1.9.0"
-wasm-bindgen = "0.2.78"
-wasm-bindgen-futures = "0.4.28"
+once_cell = "1.10.0"
+wasm-bindgen = "0.2.80"
+wasm-bindgen-futures = "0.4.30"
 yew = "0.19.3"
 bounce-macros = { path = "../bounce-macros", version = "0.3.0" }
-futures = "0.3.19"
-async-trait = { version = "0.1.52", optional = true }
+futures = "0.3.21"
+async-trait = { version = "0.1.53", optional = true }
 gloo = { version = "0.7.0", features = ["futures"], optional = true }
 
 [dependencies.web-sys]
-version = "0.3.55"
+version = "0.3.57"
 optional = true
 features = [
     "Document",
@@ -42,11 +42,11 @@ query = ["async-trait"]
 helmet = ["gloo", "web-sys"]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = "0.3.30"
 gloo = { version = "0.7.0", features = ["futures"] }
 
 [dev-dependencies.web-sys]
-version = "0.3.55"
+version = "0.3.57"
 features = [
     "HtmlInputElement",
 ]

--- a/crates/bounce/src/query/mod.rs
+++ b/crates/bounce/src/query/mod.rs
@@ -12,7 +12,7 @@
 //!
 //! Bounce does not provide an implementation of HTTP Client.
 //!
-//! You can use reqwest or reqwasm if you need a generic HTTP Client.
+//! You can use reqwest or gloo-net if you need a generic HTTP Client.
 //!
 //! If your backend is GraphQL, you can use graphql-client in conjunction with reqwest.
 

--- a/crates/bounce/tests/query.rs
+++ b/crates/bounce/tests/query.rs
@@ -1,0 +1,107 @@
+#![cfg(feature = "query")]
+
+use std::convert::Infallible;
+use std::rc::Rc;
+use std::time::Duration;
+
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+use async_trait::async_trait;
+use bounce::prelude::*;
+use bounce::query::{use_query_value, Query, QueryResult};
+use bounce::BounceRoot;
+use gloo::timers::future::sleep;
+use gloo::utils::document;
+use wasm_bindgen_futures::spawn_local;
+use yew::prelude::*;
+
+async fn get_text_content<S: AsRef<str>>(selector: S) -> String {
+    sleep(Duration::ZERO).await;
+
+    document()
+        .query_selector(selector.as_ref())
+        .unwrap()
+        .unwrap()
+        .text_content()
+        .unwrap()
+}
+
+#[test]
+async fn test_query_requery_upon_state_change() {
+    #[derive(PartialEq, Default, Atom)]
+    pub struct MyState {
+        inner: usize,
+    }
+
+    #[derive(PartialEq, Default)]
+    pub struct MyQuery {
+        inner: usize,
+    }
+
+    #[async_trait(?Send)]
+    impl Query for MyQuery {
+        type Input = ();
+        type Error = Infallible;
+
+        async fn query(states: &BounceStates, _input: Rc<()>) -> QueryResult<Self> {
+            let inner = states.get_atom_value::<MyState>().inner;
+
+            sleep(Duration::ZERO).await;
+
+            Ok(MyQuery { inner }.into())
+        }
+    }
+
+    #[function_component(Comp)]
+    fn comp() -> Html {
+        let my_query = use_query_value::<MyQuery>(().into());
+        let set_my_state = use_atom_setter();
+
+        use_effect_with_deps(
+            move |_| {
+                spawn_local(async move {
+                    sleep(Duration::from_millis(50)).await;
+
+                    set_my_state(MyState { inner: 1 });
+                });
+
+                || {}
+            },
+            (),
+        );
+
+        match my_query.result() {
+            None => {
+                html! { <div id="content">{"Loading..."}</div> }
+            }
+            Some(Ok(m)) => {
+                html! { <div id="content">{format!("value: {}", m.inner)}</div> }
+            }
+            Some(Err(_)) => unreachable!(),
+        }
+    }
+
+    #[function_component(App)]
+    fn app() -> Html {
+        html! {
+            <BounceRoot>
+                <Comp />
+            </BounceRoot>
+        }
+    }
+
+    yew::start_app_in_element::<App>(document().query_selector("#output").unwrap().unwrap());
+
+    let s = get_text_content("#content").await;
+    assert_eq!(s, "Loading...");
+
+    let s = get_text_content("#content").await;
+    assert_eq!(s, "value: 0");
+
+    sleep(Duration::from_millis(100)).await;
+
+    let s = get_text_content("#content").await;
+    assert_eq!(s, "value: 1");
+}

--- a/examples/divisibility-input/Cargo.toml
+++ b/examples/divisibility-input/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 bounce = { path = "../../crates/bounce" }
 yew = "0.19.3"
 stylist = { version = "0.10.0", features = ["yew_integration"] }
-log = "0.4.14"
+log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-wasm-bindgen = "0.2.78"
+wasm-bindgen = "0.2.80"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
-gloo = { version = "0.6.0", features = ["futures"] }
-web-sys = "0.3"
+wasm-bindgen-test = "0.3.30"
+gloo = { version = "0.7.0", features = ["futures"] }
+web-sys = "0.3.57"

--- a/examples/divisibility/Cargo.toml
+++ b/examples/divisibility/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 bounce = { path = "../../crates/bounce" }
 yew = "0.19.3"
 stylist = { version = "0.10.0", features = ["yew_integration"] }
-log = "0.4.14"
+log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-wasm-bindgen = "0.2.78"
+wasm-bindgen = "0.2.80"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
-gloo = { version = "0.6.0", features = ["futures"] }
-web-sys = "0.3"
+wasm-bindgen-test = "0.3.30"
+gloo = { version = "0.7.0", features = ["futures"] }
+web-sys = "0.3.57"

--- a/examples/helmet-title/Cargo.toml
+++ b/examples/helmet-title/Cargo.toml
@@ -8,14 +8,12 @@ edition = "2021"
 [dependencies]
 bounce = { path = "../../crates/bounce", features = ["helmet"] }
 yew = "0.19.3"
-log = "0.4.14"
+log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-wasm-bindgen = "0.2.78"
-yew-router = "0.16"
-gloo = { version = "0.6.0", features = ["futures"] }
-
-[dependencies.web-sys]
-version = "0.3.55"
+wasm-bindgen = "0.2.80"
+yew-router = "0.16.0"
+gloo = { version = "0.7.0", features = ["futures"] }
+web-sys= "0.3.57"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = "0.3.30"

--- a/examples/notion/Cargo.toml
+++ b/examples/notion/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 bounce = { path = "../../crates/bounce" }
 yew = "0.19.3"
 stylist = { version = "0.10.0", features = ["yew_integration"] }
-log = "0.4.14"
+log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-wasm-bindgen = "0.2.78"
+wasm-bindgen = "0.2.80"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
-gloo = { version = "0.6.0", features = ["futures"] }
-web-sys = "0.3"
+wasm-bindgen-test = "0.3.30"
+gloo = { version = "0.7.0", features = ["futures"] }
+web-sys = "0.3.57"

--- a/examples/partial-render/Cargo.toml
+++ b/examples/partial-render/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 bounce = { path = "../../crates/bounce" }
 yew = "0.19.3"
 stylist = { version = "0.10.0", features = ["yew_integration"] }
-log = "0.4.14"
+log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-wasm-bindgen = "0.2.78"
+wasm-bindgen = "0.2.80"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
-gloo = { version = "0.6.0", features = ["futures"] }
-web-sys = "0.3"
+wasm-bindgen-test = "0.3.30"
+gloo = { version = "0.7.0", features = ["futures"] }
+web-sys = "0.3.57"

--- a/examples/persist/Cargo.toml
+++ b/examples/persist/Cargo.toml
@@ -8,16 +8,16 @@ edition = "2021"
 [dependencies]
 bounce = { path = "../../crates/bounce" }
 yew = "0.19.3"
-log = "0.4.14"
+log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-wasm-bindgen = "0.2.78"
-gloo = { version = "0.6.0", features = ["futures"] }
+wasm-bindgen = "0.2.80"
+gloo = { version = "0.7.0", features = ["futures"] }
 
 [dependencies.web-sys]
-version = "0.3.55"
+version = "0.3.57"
 features = [
     "HtmlInputElement",
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = "0.3.30"

--- a/examples/queries-mutations/Cargo.toml
+++ b/examples/queries-mutations/Cargo.toml
@@ -8,21 +8,21 @@ edition = "2021"
 [dependencies]
 bounce = { path = "../../crates/bounce", features = ["query"] }
 yew = "0.19.3"
-log = "0.4.14"
+log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-reqwest = { version = "0.11.8", features = ["json"] }
-serde = { version = "1.0.132", features = ["derive"] }
-uuid = { version = "0.8.2", features = ["wasm-bindgen", "serde"] }
-async-trait = "0.1.52"
-wasm-bindgen-futures = "0.4.28"
-wasm-bindgen = "0.2.78"
+reqwest = { version = "0.11.10", features = ["json"] }
+serde = { version = "1.0.137", features = ["derive"] }
+uuid = { version = "1.0.0", features = ["serde"] }
+async-trait = "0.1.53"
+wasm-bindgen-futures = "0.4.30"
+wasm-bindgen = "0.2.80"
 
 [dependencies.web-sys]
-version = "0.3.55"
+version = "0.3.57"
 features = [
     "HtmlInputElement",
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
-gloo = { version = "0.6.0", features = ["futures"] }
+wasm-bindgen-test = "0.3.30"
+gloo = { version = "0.7.0", features = ["futures"] }

--- a/examples/random-uuid/Cargo.toml
+++ b/examples/random-uuid/Cargo.toml
@@ -8,18 +8,18 @@ edition = "2021"
 [dependencies]
 bounce = { path = "../../crates/bounce" }
 yew = "0.19.3"
-log = "0.4.14"
+log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-reqwest = { version = "0.11.8", features = ["json"] }
-serde = { version = "1.0.132", features = ["derive"] }
-wasm-bindgen = "0.2.78"
+reqwest = { version = "0.11.10", features = ["json"] }
+serde = { version = "1.0.137", features = ["derive"] }
+wasm-bindgen = "0.2.80"
 
 [dependencies.web-sys]
-version = "0.3.55"
+version = "0.3.57"
 features = [
     "HtmlInputElement",
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
-gloo = { version = "0.6.0", features = ["futures"] }
+wasm-bindgen-test = "0.3.30"
+gloo = { version = "0.7.0", features = ["futures"] }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -8,16 +8,16 @@ edition = "2021"
 [dependencies]
 bounce = { path = "../../crates/bounce" }
 yew = "0.19.3"
-log = "0.4.14"
+log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-wasm-bindgen = "0.2.78"
+wasm-bindgen = "0.2.80"
 
 [dependencies.web-sys]
-version = "0.3.55"
+version = "0.3.57"
 features = [
     "HtmlInputElement",
 ]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
-gloo = { version = "0.6.0", features = ["futures"] }
+wasm-bindgen-test = "0.3.30"
+gloo = { version = "0.7.0", features = ["futures"] }

--- a/examples/title/Cargo.toml
+++ b/examples/title/Cargo.toml
@@ -8,14 +8,12 @@ edition = "2021"
 [dependencies]
 bounce = { path = "../../crates/bounce" }
 yew = "0.19.3"
-log = "0.4.14"
+log = "0.4.17"
 console_log = { version = "0.2.0", features = ["color"] }
-wasm-bindgen = "0.2.78"
-yew-router = "0.16"
-gloo = { version = "0.6.0", features = ["futures"] }
-
-[dependencies.web-sys]
-version = "0.3.55"
+wasm-bindgen = "0.2.80"
+yew-router = "0.16.0"
+gloo = { version = "0.7.0", features = ["futures"] }
+web-sys= "0.3.57"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = "0.3.30"


### PR DESCRIPTION
### Description

Fix #23 

This pull request consists of the following changes:

- Bounce will now invalidate the query when any states selected by the query has updated their value.

### Checklist

- [x] I have self-reviewed and tested this pull request to my best ability.
- [x] I have added tests for my changes.
- [x] I have updated docs to reflect any new features / changes in this pull request.
- [x] I have added my changes to `CHANGELOG.md`.
